### PR TITLE
Add AppVeyor build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Folders
 _obj
 _test
+tmp
 
 # Architecture specific extensions/prefixes
 *.[568vq]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,7 @@
-FROM ubuntu:14.04
+FROM microsoft/nanoserver
 
-RUN apt-get update && apt-get install -y golang-go
-RUN apt-get install bash
-ADD . /app
-WORKDIR /app
-RUN go build -o http
+COPY tmp /
 ENV PORT 8000
 EXPOSE 8000
 
-CMD ["/app/http"]
+CMD ["\\http.exe"]

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,0 +1,6 @@
+FROM golang:nanoserver
+
+COPY . /code
+WORKDIR /code
+
+RUN go build http.go

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # whoami for Windows
+[![Build status](https://ci.appveyor.com/api/projects/status/bhma7tmx0eje73ao/branch/master?svg=true)](https://ci.appveyor.com/project/StefanScherer/whoami/branch/master)
 
 Simple HTTP docker service that prints it's container ID
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
-whoami
-======
+# whoami for Windows
 
 Simple HTTP docker service that prints it's container ID
 
-    $ docker run -d -p 8000:8000 --name whoami -t jwilder/whoami
+    $ docker run -d -p 8000:8000 --name whoami -t stefanscherer/whoami-windows
     736ab83847bb12dddd8b09969433f3a02d64d5b0be48f7a5c59a594e3a6a3541
-    
-    $ curl $(hostname --all-ip-addresses | awk '{print $1}'):8000
+
+    $ iwr http://$(docker inspect -f '{{ .NetworkSettings.Networks.nat.IPAddress }}' whoami):8000
     I'm 736ab83847bb

--- a/README.md
+++ b/README.md
@@ -5,5 +5,5 @@ Simple HTTP docker service that prints it's container ID
     $ docker run -d -p 8000:8000 --name whoami -t stefanscherer/whoami-windows
     736ab83847bb12dddd8b09969433f3a02d64d5b0be48f7a5c59a594e3a6a3541
 
-    $ iwr http://$(docker inspect -f '{{ .NetworkSettings.Networks.nat.IPAddress }}' whoami):8000
+    $ (iwr http://$(docker inspect -f '{{ .NetworkSettings.Networks.nat.IPAddress }}' whoami):8000 -UseBasicParsing).Content
     I'm 736ab83847bb

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,19 @@
+version: 1.0.{build}
+environment:
+  DOCKER_USER:
+    secure: LjNiW/ZWrfVIJn3Mc9foeg==
+  DOCKER_PASS:
+    secure: DWlZYy4BAD1B2oovKAqeUQc8N1fNtr78Yd/hwX6AwQrqCHnyC+Tt/SjjzeWEje0P
+install:
+  - choco install -y docker -pre
+  - choco install -y curl
+  - curl.exe -s http://whatismijnip.nl
+  - docker version
+
+build_script:
+  - ps: .\build.ps1
+
+deploy_script:
+  - ps: .\deploy.ps1
+
+test: off

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,21 @@
+$ErrorActionPreference = 'Stop';
+$files = ""
+Write-Host Starting build
+
+Write-Host Updating base images
+docker pull microsoft/windowsservercore
+docker pull microsoft/nanoserver
+
+Write-Host Removing old images
+$ErrorActionPreference = 'SilentlyContinue';
+docker rmi $(docker images --no-trunc --format '{{.Repository}}:{{.Tag}}' | sls -notmatch -pattern '(REPOSITORY|microsoft\/(windowsservercore|nanoserver))')
+$ErrorActionPreference = 'Stop';
+Write-Host Prune system
+docker system prune -f
+
+docker build -t httpbuild -f Dockerfile.build .
+docker create --name httpbuild httpbuild
+docker cp httpbuild:/code/http.exe tmp
+docker build -t whoami .
+
+docker images

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+docker build -t httpbuild -f Dockerfile.build .
+docker rm -f httpbuild
+docker create --name httpbuild httpbuild
+rm -rf tmp
+mkdir tmp
+docker cp httpbuild:/code/http.exe tmp
+docker build -t whoami .

--- a/deploy.ps1
+++ b/deploy.ps1
@@ -1,0 +1,14 @@
+$ErrorActionPreference = 'Stop';
+
+if (! (Test-Path Env:\APPVEYOR_REPO_TAG_NAME)) {
+  Write-Host "No version tag detected. Skip publishing."
+  exit 0
+}
+
+Write-Host Starting deploy
+docker login -u="$env:DOCKER_USER" -p="$env:DOCKER_PASS"
+
+docker tag whoami stefanscherer/whoami-windows:$env:APPVEYOR_REPO_TAG_NAME
+docker tag whoami stefanscherer/whoami-windows:latest
+docker push stefanscherer/whoami-windows:$env:APPVEYOR_REPO_TAG_NAME
+docker push stefanscherer/whoami-windows:latest


### PR DESCRIPTION
Use AppVeyor to build the Go binary as well as the Windows Docker image.
Publish the Docker image only if a release tag exists.
