### PR TITLE
Add timestamp on return

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@ Simple HTTP docker service that prints it's container ID
     736ab83847bb12dddd8b09969433f3a02d64d5b0be48f7a5c59a594e3a6a3541
     
     $ curl $(hostname --all-ip-addresses | awk '{print $1}'):8000
-    I'm 736ab83847bb
+    I am 736ab83847bb - 2018-02-01 20:44:24.234800489 +0000 UTC m=+531.949067462

--- a/http.go
+++ b/http.go
@@ -18,7 +18,7 @@ func main() {
     hostname, _ := os.Hostname()
     http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
         fmt.Fprintf(os.Stdout, "I am %s - %s\n", hostname, time.Now())
- 	      fmt.Fprintf(w, "I am %s - %s\n", hostname, time.Now())
+        fmt.Fprintf(w, "I am %s - %s\n", hostname, time.Now())
     })
 
 

--- a/http.go
+++ b/http.go
@@ -5,6 +5,7 @@ import (
   "fmt"
   "net/http"
   "log"
+  "time"
 )
 
 func main() {
@@ -16,11 +17,10 @@ func main() {
     fmt.Fprintf(os.Stdout, "Listening on :%s\n", port)
     hostname, _ := os.Hostname()
     http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-        fmt.Fprintf(os.Stdout, "I'm %s\n", hostname)
- 	fmt.Fprintf(w, "I'm %s\n", hostname)
+        fmt.Fprintf(os.Stdout, "I am %s - %s\n", hostname, time.Now())
+ 	      fmt.Fprintf(w, "I am %s - %s\n", hostname, time.Now())
     })
 
 
     log.Fatal(http.ListenAndServe(":" + port, nil))
 }
-


### PR DESCRIPTION
I'm using this project to test concurrent exec. The timestamp helped me to identify who was called. So I think it is a good idea. 